### PR TITLE
fix gaussian scaling/accuracy, resolve #248, integer queries

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,19 @@
 ### v0.1.1
+* Fix noise scaling issues in the Gaussian and Analytic Gaussian mechanism
+* Fixes for Gaussian and Analytic Gaussian accuracy
+* Compute sensitivities as integers whenever possible (counts, histograms, sums)
+* Added runtime sanity checks to detect violations of static properties in pre-aggregated data
+
+### v0.1
+* Renamed package to Smartnoise, version number reset
+* Added snapping mechanism
+* Added analytic gaussian mechanism
+* Added DP Linear Regression through the Theil-Sen transform and gumbel mechanism
+* Added generalized resize for privacy amplification by subsampling
+* Tightened c-stability checks to protect against adversarial dataset reordering when unioning data partitions
+* Modified error messages to contain suggested fixes
+* Bugfix to retain statistics when generating reports
+
+### v0.1.1
 * Fixed privacy usage such that delta == 0 is allowed.
 * Split check_params function into check_epsilon and check_delta

--- a/History.md
+++ b/History.md
@@ -5,6 +5,9 @@
 * Added runtime sanity checks to detect violations of static properties in pre-aggregated data
 * O(n^2) -> O(n) runtime performance in exponential mechanism and categorical imputation
 * Fixed an incorrect inference of dataset size when transforming a dataset with unknown size against a broadcastable scalar
+* Unions always permitted on public data
+* Added inference of nature (categories, bounds) to ToInt
+* Plug-in mean derives bounds for sum in laplace and geometric mechanism
 
 ### v0.1
 * Renamed package to Smartnoise, version number reset

--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@
 * Fixes for Gaussian and Analytic Gaussian accuracy
 * Compute sensitivities as integers whenever possible (counts, histograms, sums)
 * Added runtime sanity checks to detect violations of static properties in pre-aggregated data
+* O(n^2) -> O(n) runtime performance in exponential mechanism and categorical imputation
+* Fixed an incorrect inference of dataset size when transforming a dataset with unknown size against a broadcastable scalar
 
 ### v0.1
 * Renamed package to Smartnoise, version number reset

--- a/runtime-rust/src/components/mechanisms.rs
+++ b/runtime-rust/src/components/mechanisms.rs
@@ -34,6 +34,10 @@ impl Evaluable for proto::LaplaceMechanism {
         if num_rows != sens_num_rows {
             return Err(Error::from(format!("data has {:?} rows, while the expected shape has {:?} rows. This is likely an error from substituting data into the graph.", num_rows, sens_num_rows)))
         }
+        if data.ndim() > 2 {
+            return Err(Error::from("data may not have dimensionality greater than 2"))
+        }
+
 
         let usages = spread_privacy_usage(&self.privacy_usage, num_columns as usize)?;
         let epsilon = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
@@ -80,6 +84,9 @@ impl Evaluable for proto::GaussianMechanism {
         if num_rows != sens_num_rows {
             return Err(Error::from(format!("data has {:?} rows, while the expected shape has {:?} rows. This is likely an error from substituting data into the graph.", num_rows, sens_num_rows)))
         }
+        if data.ndim() > 2 {
+            return Err(Error::from("data may not have dimensionality greater than 2"))
+        }
 
         let usages = spread_privacy_usage(&self.privacy_usage, num_columns as usize)?;
 
@@ -124,6 +131,9 @@ impl Evaluable for proto::SimpleGeometricMechanism {
         }
         if num_rows != sens_num_rows {
             return Err(Error::from(format!("data has {:?} rows, while the expected shape has {:?} rows. This is likely an error from substituting data into the graph.", num_rows, sens_num_rows)))
+        }
+        if data.ndim() > 2 {
+            return Err(Error::from("data may not have dimensionality greater than 2"))
         }
 
         let usages = spread_privacy_usage(&self.privacy_usage, num_columns as usize)?;
@@ -191,6 +201,12 @@ impl Evaluable for proto::ExponentialMechanism {
         if sensitivity.len() != 1 {
             return Err(Error::from(format!("sensitivity has length {:?}, but should have length one. This is likely an error from substituting data into the graph.", sensitivity.len())))
         }
+        if utilities.ndim() > 2 {
+            return Err(Error::from("utilities may not have dimensionality greater than 2"))
+        }
+        if candidates.shape().len() > 2 {
+            return Err(Error::from("candidates may not have dimensionality greater than 2"))
+        }
 
         macro_rules! apply_exponential {
             ($candidates:ident) => {
@@ -243,6 +259,9 @@ impl Evaluable for proto::SnappingMechanism {
         }
         if num_rows != sens_num_rows {
             return Err(Error::from(format!("data has {:?} rows, while the expected shape has {:?} rows. This is likely an error from substituting data into the graph.", num_rows, sens_num_rows)))
+        }
+        if data.ndim() > 2 {
+            return Err(Error::from("data may not have dimensionality greater than 2"))
         }
 
         let usages = spread_privacy_usage(

--- a/runtime-rust/src/components/theil_sen.rs
+++ b/runtime-rust/src/components/theil_sen.rs
@@ -130,8 +130,8 @@ pub mod tests {
     use super::*;
 
     pub fn test_dataset(n: Integer) -> (Vec<Float>, Vec<Float>) {
-        let x = (0..n).map(|i| i as f64 + noise::sample_gaussian(0., 0.1, false).unwrap()).collect();
-        let y = (0..n).map(|i| (2 * i) as f64 + noise::sample_gaussian(0., 0.1, false).unwrap()).collect();
+        let x = (0..n).map(|i| i as f64 + noise::sample_gaussian(0., 0.01, false).unwrap()).collect();
+        let y = (0..n).map(|i| (2 * i) as f64 + noise::sample_gaussian(0., 0.01, false).unwrap()).collect();
         (x, y)
     }
 

--- a/runtime-rust/src/utilities/mechanisms.rs
+++ b/runtime-rust/src/utilities/mechanisms.rs
@@ -29,8 +29,11 @@ use smartnoise_validator::components::gaussian_mechanism::get_analytic_gaussian_
 /// let n = laplace_mechanism(0.1, 2.0, false);
 /// ```
 pub fn laplace_mechanism(epsilon: f64, sensitivity: f64, enforce_constant_time: bool) -> Result<f64> {
-    if epsilon < 0. || sensitivity < 0. {
-        return Err(format!("epsilon ({}) and sensitivity ({}) must be positive", epsilon, sensitivity).into());
+    if sensitivity < 0. {
+        return Err(format!("sensitivity ({}) must be non-negative", sensitivity).into());
+    }
+    if epsilon <= 0. {
+        return Err(format!("epsilon ({}) must be positive", epsilon).into())
     }
     let scale: f64 = sensitivity / epsilon;
     noise::sample_laplace(0., scale, enforce_constant_time)
@@ -114,11 +117,14 @@ pub fn snapping_mechanism(
 
 /// Returns noise drawn according to the Gaussian mechanism.
 ///
+/// If using the standard guassian,
 /// Let c = sqrt(2*ln(1.25/delta)). Noise is drawn from a Gaussian distribution with scale
 /// sensitivity*c/epsilon and centered about 0.
-///
 /// For more information, see the Gaussian mechanism in
 /// C. Dwork, A. Roth The Algorithmic Foundations of Differential Privacy, Chapter 3.5.3 Laplace versus Gauss p.53. August 2014.
+///
+/// If using the analytic gaussian,
+/// the noise scale is derived using [Balle (2018)](https://arxiv.org/pdf/1805.06530.pdf).
 ///
 /// NOTE: this implementation of Gaussian draws in likely non-private due to floating-point attacks
 /// See [Mironov (2012)](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.366.5957&rep=rep1&type=pdf)

--- a/runtime-rust/src/utilities/mod.rs
+++ b/runtime-rust/src/utilities/mod.rs
@@ -326,7 +326,7 @@ pub fn sample_from_set<T>(
         }
     }
     // this should only ever be reachable from floating-point instability
-    return candidate_set[candidate_set.len() - 1].clone()
+    return Ok(candidate_set[candidate_set.len() - 1].clone())
 }
 
 #[cfg(not(feature="use-mpfr"))]

--- a/runtime-rust/src/utilities/mod.rs
+++ b/runtime-rust/src/utilities/mod.rs
@@ -25,6 +25,13 @@ pub fn get_num_columns<T>(data: &ArrayD<T>) -> Result<i64> {
         _ => Err("data may be at most 2-dimensional".into())
     }
 }
+pub fn get_num_rows<T>(data: &ArrayD<T>) -> Result<i64> {
+    match data.ndim() {
+        0 => Ok(1),
+        1 | 2 => Ok(data.len_of(Axis(0)) as i64),
+        _ => Err("data may be at most 2-dimensional".into())
+    }
+}
 
 
 /// Broadcast left and right to match each other, and map an operator over the pairs.

--- a/runtime-rust/src/utilities/noise.rs
+++ b/runtime-rust/src/utilities/noise.rs
@@ -513,7 +513,7 @@ pub fn sample_gaussian(shift: f64, scale: f64, _enforce_constant_time: bool) -> 
     // NOTE: We square the scale here because we ask for the standard deviation as the function input, but
     //       the mpfr library wants the variance. We ask for std. dev. to be consistent with the rest of the library.
     let mpfr_shift = Float::with_val(53, shift);
-    let mpfr_scale = Float::with_val(53, Float::with_val(53, scale));
+    let mpfr_scale = Float::with_val(53, scale);
 
     // initialize randomness
     let mut rng = GeneratorOpenSSL {};

--- a/runtime-rust/src/utilities/noise.rs
+++ b/runtime-rust/src/utilities/noise.rs
@@ -432,18 +432,16 @@ pub fn sample_uniform_mpfr(min: f64, max: f64) -> Result<rug::Float> {
     // initialize 64-bit floats within mpfr/rug
     let mpfr_min = Float::with_val(53, min);
     let mpfr_max = Float::with_val(53, max);
-    let mpfr_diff = Float::with_val(53, &mpfr_max - &mpfr_min);
 
     // initialize randomness
     let mut rng = GeneratorOpenSSL {};
     let mut state = ThreadRandState::new_custom(&mut rng);
 
     // generate Unif[0,1] according to mpfr standard, then convert to correct scale
-    let mut unif = Float::with_val(53, Float::random_cont(&mut state));
-    unif = unif.mul_add(&mpfr_diff, &mpfr_min);
+    let unif = Float::with_val(53, Float::random_cont(&mut state));
 
     // return uniform
-    Ok(unif)
+    Ok(unif.mul_add(&(mpfr_max - &mpfr_min), &mpfr_min))
 }
 
 /// Sample from Laplace distribution centered at shift and scaled by scale.

--- a/runtime-rust/src/utilities/noise.rs
+++ b/runtime-rust/src/utilities/noise.rs
@@ -410,7 +410,7 @@ mod test_uniform {
 
 /// Returns random sample from Uniform[min,max) using the MPFR library.
 ///
-/// If [min, max) == [0, 1),then this is done in a way that respects exact rounding.
+/// If [min, max) == [0, 1), then this is done in a way that respects exact rounding.
 /// Otherwise, the return will be the result of a composition of two operations that
 /// respect exact rounding (though the result will not necessarily).
 ///
@@ -664,7 +664,7 @@ pub fn sample_simple_geometric_mechanism(
 /// * `value` - Non-private value of the statistic to be privatized.
 /// * `epsilon` - Desired privacy guarantee.
 /// * `b` - Upper bound on function value being privatized.
-/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time;
+/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time
 ///
 /// # Returns
 /// Value of statistic with noise applied according to the Snapping mechanism.

--- a/runtime-rust/src/utilities/noise.rs
+++ b/runtime-rust/src/utilities/noise.rs
@@ -513,7 +513,7 @@ pub fn sample_gaussian(shift: f64, scale: f64, _enforce_constant_time: bool) -> 
     // NOTE: We square the scale here because we ask for the standard deviation as the function input, but
     //       the mpfr library wants the variance. We ask for std. dev. to be consistent with the rest of the library.
     let mpfr_shift = Float::with_val(53, shift);
-    let mpfr_scale = Float::with_val(53, Float::with_val(53, scale).square());
+    let mpfr_scale = Float::with_val(53, Float::with_val(53, scale));
 
     // initialize randomness
     let mut rng = GeneratorOpenSSL {};

--- a/validator-rust/prototypes/components/DPSum.json
+++ b/validator-rust/prototypes/components/DPSum.json
@@ -24,7 +24,7 @@
       "type_rust": "String",
       "default_python": "\"Automatic\"",
       "default_rust": "String::from(\"Automatic\")",
-      "description": "Privatizing mechanism to use. One of [`Automatic`, `Laplace`, `Gaussian`, `AnalyticGaussian`, `SimpleGeometric`]. `Automatic` chooses based on the input data type."
+      "description": "Privatizing mechanism to use. One of [`Automatic`, `Laplace`, `Snapping`, `Gaussian`, `AnalyticGaussian`, `SimpleGeometric`]. `Automatic` chooses based on the input data type."
     },
     "privacy_usage": {
       "type_proto": "repeated PrivacyUsage",

--- a/validator-rust/src/base.rs
+++ b/validator-rust/src/base.rs
@@ -243,6 +243,14 @@ impl Array {
             Array::Str(_) => Err("atomic type: expected float, got string".into()),
         }
     }
+    pub fn cast_float(self) -> Result<ArrayD<f64>> {
+        match self {
+            Array::Float(x) => Ok(x),
+            Array::Int(x) => Ok(x.mapv(|v| v as Float)),
+            Array::Bool(_) => Err("atomic type: expected float, got bool".into()),
+            Array::Str(_) => Err("atomic type: expected float, got string".into()),
+        }
+    }
     pub fn ref_float(&self) -> Result<&ArrayD<Float>> {
         match self {
             Array::Float(x) => Ok(x),

--- a/validator-rust/src/base.rs
+++ b/validator-rust/src/base.rs
@@ -751,15 +751,15 @@ impl JaggedProperties {
 impl ArrayProperties {
     pub fn lower(&self) -> Result<Array> {
         Ok(match (self.lower_float(), self.lower_int()) {
+            (_, Ok(lower)) => Array::Int(ndarray::arr1(&lower).into_dyn()),
             (Ok(lower), Err(_)) => Array::Float(ndarray::arr1(&lower).into_dyn()),
-            (Err(_), Ok(lower)) => Array::Int(ndarray::arr1(&lower).into_dyn()),
             _ => return Err("Lower bound unknown. Use a clamp to set data bounds.".into())
         })
     }
     pub fn upper(&self) -> Result<Array> {
         Ok(match (self.upper_float(), self.upper_int()) {
+            (_, Ok(upper)) => Array::Int(ndarray::arr1(&upper).into_dyn()),
             (Ok(upper), Err(_)) => Array::Float(ndarray::arr1(&upper).into_dyn()),
-            (Err(_), Ok(upper)) => Array::Int(ndarray::arr1(&upper).into_dyn()),
             _ => return Err("Upper bound unknown. Use a clamp to set data bounds.".into())
         })
     }

--- a/validator-rust/src/components/cast.rs
+++ b/validator-rust/src/components/cast.rs
@@ -90,7 +90,6 @@ impl Component for proto::Cast {
                 get_argument(&public_arguments, "upper")?.ref_array()?.first_int()
                     .map_err(prepend("type:"))?;
 
-                data_property.nature = None;
                 data_property.nature = match data_property.nature {
                     Some(nature) => match nature.clone() {
                         Nature::Categorical(cat_nature) => match cat_nature.categories {

--- a/validator-rust/src/components/count.rs
+++ b/validator-rust/src/components/count.rs
@@ -1,7 +1,7 @@
 use indexmap::map::IndexMap;
 use ndarray::arr1;
 
-use crate::{base, Float, Integer, proto, Warnable};
+use crate::{base, Integer, proto, Warnable};
 use crate::base::{AggregatorProperties, DataType, IndexKey, Nature, NatureContinuous, NodeProperties, SensitivitySpace, Value, ValueProperties, Vector1DNull};
 use crate::components::{Component, Sensitivity};
 use crate::errors::*;
@@ -100,15 +100,15 @@ impl Sensitivity for proto::Count {
                     .ok_or_else(|| Error::from("neighboring definition must be either \"AddRemove\" or \"Substitute\""))?;
 
                 // SENSITIVITY DERIVATIONS
-                let sensitivity: Float = match (neighboring_type, num_records) {
+                let sensitivity = match (neighboring_type, num_records) {
                     // known N. Applies to any neighboring type.
-                    (_, Some(_)) => 0.,
+                    (_, Some(_)) => 0,
 
                     // unknown N. The sensitivity here is really zero-- artificially raised
-                    (Substitute, None) => 1.,
+                    (Substitute, None) => 1,
 
                     // unknown N
-                    (AddRemove, None) => 1.,
+                    (AddRemove, None) => 1,
                 };
                 Ok((arr1(&[sensitivity]).into_dyn()).into())
             },

--- a/validator-rust/src/components/dp_mean.rs
+++ b/validator-rust/src/components/dp_mean.rs
@@ -4,8 +4,9 @@ use crate::{base, proto};
 use crate::base::{IndexKey, NodeProperties, Value};
 use crate::components::{Expandable, Report};
 use crate::errors::*;
-use crate::utilities::{array::get_ith_column, prepend, privacy::spread_privacy_usage};
+use crate::utilities::{array::get_ith_column, prepend, privacy::spread_privacy_usage, get_literal};
 use crate::utilities::json::{AlgorithmInfo, JSONRelease, privacy_usage_to_json, value_to_json};
+use crate::utilities::inference::infer_property;
 
 impl Expandable for proto::DpMean {
     /// Expand component
@@ -28,35 +29,26 @@ impl Expandable for proto::DpMean {
         let mut expansion = base::ComponentExpansion::default();
         let argument_ids = component.arguments();
 
-        if self.implementation.to_lowercase().as_str() == "plug-in" {
+        let mechanism = if self.mechanism.to_lowercase().as_str() == "automatic" {
+            let privacy_definition = privacy_definition.as_ref()
+                .ok_or_else(|| Error::from("privacy_definition must be known"))?;
+            if privacy_definition.protect_floating_point
+            { "snapping" } else { "laplace" }.to_string()
+        } else { self.mechanism.to_lowercase() };
 
-            let num_columns = properties.get::<base::IndexKey>(&"data".into())
+        if self.implementation.to_lowercase() == "plug-in" {
+
+            let data_property = properties.get::<base::IndexKey>(&"data".into())
                 .ok_or("data: missing")?.array()
-                .map_err(prepend("data:"))?.num_columns()? as f64;
+                .map_err(prepend("data:"))?;
+            let num_columns = data_property.num_columns()? as f64;
 
             let id_data = *argument_ids.get::<base::IndexKey>(&"data".into())
                 .ok_or_else(|| Error::from("data must be provided as an argument"))?;
 
-            // dp sum
-            maximum_id += 1;
-            let id_dp_sum = maximum_id;
-            expansion.computation_graph.insert(id_dp_sum, proto::Component {
-                arguments: Some(proto::ArgumentNodeIds::new(
-                    indexmap!["data".into() => id_data])),
-                variant: Some(proto::component::Variant::DpSum(proto::DpSum {
-                    mechanism: self.mechanism.clone(),
-                    privacy_usage: self.privacy_usage.iter().cloned()
-                        .map(|v| v / (num_columns + 1.))
-                        .collect::<Result<Vec<proto::PrivacyUsage>>>()?
-                })),
-                omit: true,
-                submission: component.submission,
-            });
-            expansion.traversal.push(id_dp_sum);
-
             // dp count
             maximum_id += 1;
-            let id_dp_count = maximum_id;
+            let mut id_dp_count = maximum_id;
             expansion.computation_graph.insert(id_dp_count, proto::Component {
                 arguments: Some(proto::ArgumentNodeIds::new(
                     indexmap!["data".into() => id_data])),
@@ -73,22 +65,109 @@ impl Expandable for proto::DpMean {
             expansion.traversal.push(id_dp_count);
 
             // to float
+            if mechanism != "simplegeometric" {
+                maximum_id += 1;
+                expansion.computation_graph.insert(maximum_id, proto::Component {
+                    arguments: Some(proto::ArgumentNodeIds::new(
+                        indexmap!["data".into() => id_dp_count])),
+                    variant: Some(proto::component::Variant::ToFloat(proto::ToFloat {})),
+                    omit: true,
+                    submission: component.submission,
+                });
+                expansion.traversal.push(maximum_id);
+                id_dp_count = maximum_id;
+            }
+
+            // one
             maximum_id += 1;
-            let id_to_float = maximum_id;
-            expansion.computation_graph.insert(id_to_float, proto::Component {
+            let id_one = maximum_id;
+            let (patch_node, zero_release) = get_literal(if mechanism == "simplegeometric" {1.into()} else {1.0.into()}, component.submission)?;
+            expansion.computation_graph.insert(id_one, patch_node);
+            expansion.properties.insert(id_one, infer_property(&zero_release.value, None, id_one)?);
+            expansion.releases.insert(id_one, zero_release);
+
+            // set lower bound on dp count
+            maximum_id += 1;
+            expansion.computation_graph.insert(maximum_id, proto::Component {
                 arguments: Some(proto::ArgumentNodeIds::new(
-                    indexmap!["data".into() => id_dp_count])),
-                variant: Some(proto::component::Variant::ToFloat(proto::ToFloat {})),
+                    indexmap!["left".into() => id_dp_count, "right".into() => id_one])),
+                variant: Some(proto::component::Variant::RowMax(proto::RowMax {})),
                 omit: true,
                 submission: component.submission,
             });
-            expansion.traversal.push(id_to_float);
+            expansion.traversal.push(maximum_id);
+            id_dp_count = maximum_id;
+
+            let mut dp_sum_arguments = indexmap!["data".into() => id_data];
+
+            // if snapping or geometric, derive lower bound for statistic
+            if mechanism == "snapping" || mechanism == "simplegeometric" {
+
+                // data lower
+                maximum_id += 1;
+                let id_data_lower = maximum_id;
+                let (patch_node, data_lower_release) = get_literal(Value::Array(data_property.lower()?), component.submission)?;
+                expansion.computation_graph.insert(id_data_lower, patch_node);
+                expansion.properties.insert(id_data_lower, infer_property(&data_lower_release.value, None, id_data_lower)?);
+                expansion.releases.insert(id_data_lower, data_lower_release);
+
+                // statistic lower bound
+                maximum_id += 1;
+                let id_sum_lower = maximum_id;
+                expansion.computation_graph.insert(id_sum_lower, proto::Component {
+                    arguments: Some(proto::ArgumentNodeIds::new(
+                        indexmap!["left".into() => id_dp_count, "right".into() => id_data_lower])),
+                    variant: Some(proto::component::Variant::Multiply(proto::Multiply {})),
+                    omit: true,
+                    submission: component.submission,
+                });
+                expansion.traversal.push(id_sum_lower);
+                dp_sum_arguments.insert("lower".into(), id_sum_lower);
+
+                // data upper
+                maximum_id += 1;
+                let id_data_upper = maximum_id;
+                let (patch_node, data_upper_release) = get_literal(Value::Array(data_property.upper()?), component.submission)?;
+                expansion.computation_graph.insert(id_data_upper, patch_node);
+                expansion.properties.insert(id_data_upper, infer_property(&data_upper_release.value, None, id_data_upper)?);
+                expansion.releases.insert(id_data_upper, data_upper_release);
+
+                // statistic upper bound
+                maximum_id += 1;
+                let id_sum_upper = maximum_id;
+                expansion.computation_graph.insert(id_sum_upper, proto::Component {
+                    arguments: Some(proto::ArgumentNodeIds::new(
+                        indexmap!["left".into() => id_dp_count, "right".into() => id_data_upper])),
+                    variant: Some(proto::component::Variant::Multiply(proto::Multiply {})),
+                    omit: true,
+                    submission: component.submission,
+                });
+                expansion.traversal.push(id_sum_upper);
+                dp_sum_arguments.insert("upper".into(), id_sum_upper);
+            };
+
+            // dp sum
+            maximum_id += 1;
+            let id_dp_sum = maximum_id;
+            expansion.computation_graph.insert(id_dp_sum, proto::Component {
+                arguments: Some(proto::ArgumentNodeIds::new(dp_sum_arguments)),
+                variant: Some(proto::component::Variant::DpSum(proto::DpSum {
+                    mechanism: self.mechanism.clone(),
+                    privacy_usage: self.privacy_usage.iter().cloned()
+                        .map(|v| v / (num_columns + 1.))
+                        .collect::<Result<Vec<proto::PrivacyUsage>>>()?
+                })),
+                omit: true,
+                submission: component.submission,
+            });
+            expansion.traversal.push(id_dp_sum);
 
             // divide
             expansion.computation_graph.insert(component_id, proto::Component {
                 arguments: Some(proto::ArgumentNodeIds::new(indexmap![
                     "left".into() => id_dp_sum,
-                    "right".into() => id_to_float])),
+                    "right".into() => id_dp_count
+                ])),
                 variant: Some(proto::component::Variant::Divide(proto::Divide {})),
                 omit: component.omit,
                 submission: component.submission,
@@ -97,7 +176,7 @@ impl Expandable for proto::DpMean {
             Ok(expansion)
         }
 
-        else if self.implementation.to_lowercase().as_str() == "resize" {
+        else if self.implementation.to_lowercase() == "resize" {
             // mean
             maximum_id += 1;
             let id_mean = maximum_id;
@@ -112,13 +191,6 @@ impl Expandable for proto::DpMean {
             expansion.traversal.push(id_mean);
 
             // noising
-            let mechanism = if self.mechanism.to_lowercase().as_str() == "automatic" {
-                let privacy_definition = privacy_definition.as_ref()
-                    .ok_or_else(|| Error::from("privacy_definition must be known"))?;
-                if privacy_definition.protect_floating_point
-                { "snapping" } else { "laplace" }.to_string()
-            } else { self.mechanism.to_lowercase() };
-
             let mut arguments = indexmap!["data".into() => id_mean];
             let variant = Some(match mechanism.as_str() {
                 "laplace" => proto::component::Variant::LaplaceMechanism(proto::LaplaceMechanism {

--- a/validator-rust/src/components/gaussian_mechanism.rs
+++ b/validator-rust/src/components/gaussian_mechanism.rs
@@ -217,39 +217,71 @@ impl Accuracy for proto::GaussianMechanism {
     }
 }
 
+/// Integrate gaussian from -inf to t
+/// P(N(0,1)≤t)
+///
+/// # Arguments
+/// * `t` - upper bound for integration
 fn phi(t: f64) -> f64 {
     0.5 * (1. + erf::erf(t / 2.0_f64.sqrt()))
 }
 
+/// B^-: Reduced form of inequality (6) for optimization when alpha > 1.
+/// Refer to p.19 Proof of Theorem 9.
+/// 1. Substitute σ = α∆/sqrt(2ε) into inequality (6)
+/// 2. Substitute u = (α−1/α)2/2
 fn case_a(epsilon: f64, s: f64) -> f64 {
     phi((epsilon * s).sqrt()) - epsilon.exp() * phi(-(epsilon * (s + 2.)).sqrt())
 }
 
+/// B^+: Reduced form of inequality (6) for optimization when alpha > 1.
+/// Refer to p.19 Proof of Theorem 9.
 fn case_b(epsilon: f64, s: f64) -> f64 {
     phi(-(epsilon * s).sqrt()) - epsilon.exp() * phi(-(epsilon * (s + 2.)).sqrt())
 }
 
+/// Obtain an interval from which to start a binary search
+/// Choice of B^+ or B^- is based on the sign determined by delta_thr
+/// The paper's example given for v* on B+ is to-- "Find the smallest k in N such that B^+_eps(2^k) > delta"
+///
+/// Returns the interval (2^(k - 1), 2^k)
 fn doubling_trick(
-    mut s_inf: f64, mut s_sup: f64, epsilon: f64, delta: f64, delta_thr: f64,
+    epsilon: f64, delta: f64, delta_thr: f64,
 ) -> (f64, f64) {
+    // base case
+    let mut s_inf: f64 = 0.;
+    let mut s_sup: f64 = 1.;
+
+    // return false when bounds should no longer be doubled
     let predicate = |s: f64| if delta > delta_thr {
         case_a(epsilon, s) < delta
     } else {
         case_b(epsilon, s) > delta
     };
 
+    // continue doubling the bounds until Theorem 8's comparison with delta is not satisfied
     while predicate(s_sup) {
         s_inf = s_sup;
         s_sup = 2.0 * s_inf;
     }
+    // return an interval of (2^(k - 1), 2^k) to search over
     (s_inf, s_sup)
 }
 
+/// Find an s* (where s corresponds to either u or v based on delta_threshold),
+///     such that B(s) lies within a positive tolerance of delta.
+///
+/// # Arguments
+/// * `s_inf` - lower bound for valid values of s
+/// * `s_sup` - upper bound for valid values of s
+/// * `epsilon` - Multiplicative privacy loss parameter.
+/// * `delta` - Additive privacy loss parameter.
+/// * `delta_thr` - threshold at which sign should be flipped
+/// * `tol` - tolerance for error in delta
 fn binary_search(
     mut s_inf: f64, mut s_sup: f64, epsilon: f64, delta: f64, delta_thr: f64, tol: f64,
 ) -> f64 {
-    let mut s_mid: f64 = s_inf + (s_sup - s_inf) / 2.;
-
+    // evaluate either B+ or B- on s
     let s_to_delta = |s: f64| if delta > delta_thr {
         case_a(epsilon, s)
     } else {
@@ -257,41 +289,64 @@ fn binary_search(
     };
 
     loop {
+        let s_mid = s_inf + (s_sup - s_inf) / 2.;
         let delta_prime = s_to_delta(s_mid);
 
+        // stop iterating if tolerance is satisfied
         let diff = delta_prime - delta;
-        if (diff.abs() <= tol) && (diff <= 0.) { break }
+        if (diff.abs() <= tol) && (diff <= 0.) { return s_mid }
 
+        // detect the side that the ideal delta falls into
         let is_left = if delta > delta_thr {
             delta_prime > delta
         } else {
             delta_prime < delta
         };
 
+        // tighten bounds about ideal delta
         if is_left {
             s_sup = s_mid;
         } else {
             s_inf = s_mid;
         }
-        s_mid = s_inf + (s_sup - s_inf) / 2.;
     }
-    s_mid
 }
 
-/// Compute the sigma to parameterize a gaussian distribution
+/// Algorithm to compute sigma for use in the analytic gaussian mechanism
+/// Using p.9, p.19 of [Balle (2018)](https://arxiv.org/pdf/1805.06530.pdf)
+///
+/// # Arguments
+/// * `epsilon` - Multiplicative privacy loss parameter.
+/// * `delta` - Additive privacy loss parameter.
+/// * `sensitivity` - Upper bound on the L2 sensitivity of the function you want to privatize.
 pub fn get_analytic_gaussian_sigma(epsilon: f64, delta: f64, sensitivity: f64) -> f64 {
+    // threshold to choose whether alpha is larger or smaller than one
     let delta_thr = case_a(epsilon, 0.);
 
+    // Algorithm 1
     let alpha = if delta == delta_thr {
         1.
     } else {
-        let (s_inf, s_sup) = doubling_trick(0., 1., epsilon, delta, delta_thr);
+        // depending on comparison with delta_thr alpha is either negative or positive
+        // searching for either:
+        //     v* = inf{u ∈ R≥0: B−ε(u)≤δ}  (where alpha positive)
+        //     u* = sup{v ∈ R≥0: B+ε(v)≤δ}  (where alpha negative)
+        // let s be a B agnostic substitution for either u or v
+
+        // use the doubling trick to bound the R≥0 region to the interval:
+        let (s_inf, s_sup) = doubling_trick(epsilon, delta, delta_thr);
+
+        // run a binary search over either B+ or B- to find s*.
         let tol: f64 = 1e-10f64;
         let s_final = binary_search(s_inf, s_sup, epsilon, delta, delta_thr, tol);
-        let sign = if delta >= delta_thr { -1. } else { 1. };
+
+        // differentiate s between the u and v based on the sign
+        let sign = if delta > delta_thr { -1. } else { 1. };
+        // reverse second transform out of simplified optimization space (p.19)
         (1. + s_final / 2.).sqrt() + sign * (s_final / 2.).sqrt()
     };
 
+    // reverse first transform out of simplified optimization space (p.19)
     alpha * sensitivity / (2. * epsilon).sqrt()
 }
 

--- a/validator-rust/src/components/gaussian_mechanism.rs
+++ b/validator-rust/src/components/gaussian_mechanism.rs
@@ -278,6 +278,7 @@ fn binary_search(
     s_mid
 }
 
+/// Compute the sigma to parameterize a gaussian distribution
 pub fn get_analytic_gaussian_sigma(epsilon: f64, delta: f64, sensitivity: f64) -> f64 {
     let delta_thr = case_a(epsilon, 0.);
 
@@ -287,8 +288,19 @@ pub fn get_analytic_gaussian_sigma(epsilon: f64, delta: f64, sensitivity: f64) -
         let (s_inf, s_sup) = doubling_trick(0., 1., epsilon, delta, delta_thr);
         let tol: f64 = 1e-10f64;
         let s_final = binary_search(s_inf, s_sup, epsilon, delta, delta_thr, tol);
-        (1. + s_final / 2.).sqrt() - (s_final / 2.).sqrt()
+        let sign = if delta >= delta_thr { -1. } else { 1. };
+        (1. + s_final / 2.).sqrt() + sign * (s_final / 2.).sqrt()
     };
 
     alpha * sensitivity / (2. * epsilon).sqrt()
+}
+
+#[cfg(test)]
+mod test_analytic_gaussian {
+    use crate::components::gaussian_mechanism::get_analytic_gaussian_sigma;
+
+    #[test]
+    fn test_analytic_gaussian_sigma() {
+        println!("{:?}", get_analytic_gaussian_sigma(0.5, 1E-10, 1.))
+    }
 }

--- a/validator-rust/src/components/gaussian_mechanism.rs
+++ b/validator-rust/src/components/gaussian_mechanism.rs
@@ -189,7 +189,7 @@ impl Accuracy for proto::GaussianMechanism {
         let sensitivity_values = aggregator.component.compute_sensitivity(
             &privacy_definition,
             &aggregator.properties,
-            &SensitivitySpace::KNorm(1))?;
+            &SensitivitySpace::KNorm(2))?;
 
         // take max sensitivity of each column
         let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?

--- a/validator-rust/src/components/impute.rs
+++ b/validator-rust/src/components/impute.rs
@@ -1,7 +1,7 @@
 use indexmap::map::IndexMap;
 
 use crate::{base, Warnable};
-use crate::base::{Array, DataType, IndexKey, Nature, NatureContinuous, Value, ValueProperties, Vector1DNull, NatureCategorical, Jagged};
+use crate::base::{DataType, IndexKey, Nature, NatureContinuous, Value, ValueProperties, Vector1DNull, NatureCategorical, Jagged};
 use crate::components::{Component, Expandable};
 use crate::errors::*;
 use crate::proto;
@@ -165,13 +165,12 @@ impl Expandable for proto::Impute {
 
         let mut expansion = base::ComponentExpansion::default();
 
-        if !properties.contains_key::<base::IndexKey>(&"categories".into()) {
-            if !properties.contains_key::<IndexKey>(&"lower".into()) {
+        if !properties.contains_key(&IndexKey::from("categories")) {
+            if !properties.contains_key(&IndexKey::from("lower")) {
                 maximum_id += 1;
                 let id_lower = maximum_id;
-                let value = Value::Array(Array::Float(
-                    ndarray::Array::from(properties.get::<IndexKey>(&"data".into())
-                        .unwrap().to_owned().array()?.lower_float()?).into_dyn()));
+                let value = Value::Array(properties.get(&IndexKey::from("data"))
+                    .unwrap().to_owned().array()?.lower()?);
                 let (patch_node, release) = get_literal(value, component.submission)?;
                 expansion.computation_graph.insert(id_lower, patch_node);
                 expansion.properties.insert(id_lower, infer_property(&release.value, None, id_lower)?);
@@ -182,9 +181,8 @@ impl Expandable for proto::Impute {
             if !properties.contains_key::<IndexKey>(&"upper".into()) {
                 maximum_id += 1;
                 let id_upper = maximum_id;
-                let value = Value::Array(Array::Float(
-                    ndarray::Array::from(properties.get::<IndexKey>(&"data".into())
-                        .unwrap().to_owned().array()?.upper_float()?).into_dyn()));
+                let value = Value::Array(properties.get(&IndexKey::from("data"))
+                    .unwrap().to_owned().array()?.upper()?);
                 let (patch_node, release) = get_literal(value, component.submission)?;
                 expansion.computation_graph.insert(id_upper, patch_node);
                 expansion.properties.insert(id_upper, infer_property(&release.value, None, id_upper)?);

--- a/validator-rust/src/components/resize.rs
+++ b/validator-rust/src/components/resize.rs
@@ -228,7 +228,7 @@ impl Component for proto::Resize {
                     upper: Vector1DNull::Int(impute_upper),
                 }));
             }
-            _ => return Err("bounds for imputation must be numeric".into())
+            _ => return Err("data in continuous imputation must be numeric".into())
         }
 
         let sample_proportion: Option<Float> = public_arguments.get(&IndexKey::from("sample_proportion"))

--- a/validator-rust/src/components/simple_geometric_mechanism.rs
+++ b/validator-rust/src/components/simple_geometric_mechanism.rs
@@ -102,7 +102,8 @@ impl Expandable for proto::SimpleGeometricMechanism {
                 .ok_or("data: missing")?.array()?.clone();
 
             if let Some(lower_id) = lower_id {
-                let (patch_node, release) = get_literal(Value::Array(data_property.lower()?), component.submission)?;
+                let (patch_node, release) = get_literal(Value::Array(data_property.lower()
+                    .map_err(|_| Error::from("lower bound on the statistic is unknown for the simple geometric mechanism. Either pass lower as an argument or sufficiently preprocess the data to make a lower bound inferrable."))?), component.submission)?;
                 expansion.computation_graph.insert(lower_id, patch_node);
                 expansion.properties.insert(lower_id, infer_property(&release.value, None, lower_id)?);
                 expansion.releases.insert(lower_id, release);
@@ -110,7 +111,8 @@ impl Expandable for proto::SimpleGeometricMechanism {
             }
 
             if let Some(upper_id) = upper_id {
-                let (patch_node, release) = get_literal(Value::Array(data_property.upper()?), component.submission)?;
+                let (patch_node, release) = get_literal(Value::Array(data_property.lower()
+                    .map_err(|_| Error::from("upper bound on the statistic is unknown for the simple geometric mechanism. Either pass upper as an argument or sufficiently preprocess the data to make an upper bound inferrable."))?), component.submission)?;
                 expansion.computation_graph.insert(upper_id, patch_node);
                 expansion.properties.insert(upper_id, infer_property(&release.value, None, upper_id)?);
                 expansion.releases.insert(upper_id, release);

--- a/validator-rust/src/components/simple_geometric_mechanism.rs
+++ b/validator-rust/src/components/simple_geometric_mechanism.rs
@@ -10,7 +10,6 @@ use crate::utilities::privacy::{spread_privacy_usage, get_epsilon, privacy_usage
 use itertools::Itertools;
 use indexmap::map::IndexMap;
 use crate::utilities::inference::infer_property;
-use ndarray::arr1;
 
 
 impl Component for proto::SimpleGeometricMechanism {
@@ -103,7 +102,7 @@ impl Expandable for proto::SimpleGeometricMechanism {
                 .ok_or("data: missing")?.array()?.clone();
 
             if let Some(lower_id) = lower_id {
-                let (patch_node, release) = get_literal(arr1(&data_property.lower_int()?).into_dyn().into(), component.submission)?;
+                let (patch_node, release) = get_literal(Value::Array(data_property.lower()?), component.submission)?;
                 expansion.computation_graph.insert(lower_id, patch_node);
                 expansion.properties.insert(lower_id, infer_property(&release.value, None, lower_id)?);
                 expansion.releases.insert(lower_id, release);
@@ -111,7 +110,7 @@ impl Expandable for proto::SimpleGeometricMechanism {
             }
 
             if let Some(upper_id) = upper_id {
-                let (patch_node, release) = get_literal(arr1(&data_property.upper_int()?).into_dyn().into(), component.submission)?;
+                let (patch_node, release) = get_literal(Value::Array(data_property.upper()?), component.submission)?;
                 expansion.computation_graph.insert(upper_id, patch_node);
                 expansion.properties.insert(upper_id, infer_property(&release.value, None, upper_id)?);
                 expansion.releases.insert(upper_id, release);

--- a/validator-rust/src/components/simple_geometric_mechanism.rs
+++ b/validator-rust/src/components/simple_geometric_mechanism.rs
@@ -160,18 +160,22 @@ impl Accuracy for proto::SimpleGeometricMechanism {
         let aggregator = data_property.aggregator
             .ok_or_else(|| Error::from("aggregator: missing"))?;
 
+        // sensitivity must be computable
         let sensitivity_values = aggregator.component.compute_sensitivity(
             &privacy_definition,
             &aggregator.properties,
             &SensitivitySpace::KNorm(1))?;
 
-        // sensitivity must be computable
-        let sensitivities = sensitivity_values.array()?.float()?;
+        // take max sensitivity of each column
+        let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?
+            .gencolumns().into_iter()
+            .map(|sensitivity_col| sensitivity_col.into_iter().copied().fold1(|l, r| l.max(r)).unwrap())
+            .collect();
 
         Ok(Some(sensitivities.into_iter().zip(accuracies.values.iter())
             .map(|(sensitivity, accuracy)| proto::PrivacyUsage {
                 distance: Some(proto::privacy_usage::Distance::Approximate(proto::privacy_usage::DistanceApproximate {
-                    epsilon: (1. / accuracy.alpha).ln() * (*sensitivity as f64 / accuracy.value),
+                    epsilon: (1. / accuracy.alpha).ln() * (sensitivity as f64 / accuracy.value),
                     delta: 0.,
                 }))
             })
@@ -189,7 +193,7 @@ impl Accuracy for proto::SimpleGeometricMechanism {
             .ok_or("data: missing")?.array()
             .map_err(prepend("data:"))?.clone();
 
-        let aggregator = data_property.aggregator
+        let aggregator = data_property.aggregator.as_ref()
             .ok_or_else(|| Error::from("aggregator: missing"))?;
 
         let sensitivity_values = aggregator.component.compute_sensitivity(
@@ -197,16 +201,20 @@ impl Accuracy for proto::SimpleGeometricMechanism {
             &aggregator.properties,
             &SensitivitySpace::KNorm(1))?;
 
-        // sensitivity must be computable
-        let sensitivities = sensitivity_values.array()?.float()?;
+        // take max sensitivity of each column
+        let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?
+            .gencolumns().into_iter()
+            .map(|sensitivity_col| sensitivity_col.into_iter().copied().fold1(|l, r| l.max(r)).unwrap())
+            .collect();
 
-        let usages = spread_privacy_usage(&self.privacy_usage, sensitivities.len())?;
+        let usages = spread_privacy_usage(&self.privacy_usage, data_property.num_columns()? as usize)?;
         let epsilon = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
 
         Ok(Some(sensitivities.into_iter().zip(epsilon.into_iter())
             .map(|(sensitivity, epsilon)| proto::Accuracy {
-                value: ((1. / alpha).ln() * (*sensitivity as f64 / epsilon)).ceil(),
+                value: ((1. / alpha).ln() * (sensitivity / epsilon) as f64).ceil(),
                 alpha
-            }).collect()))
+            })
+            .collect()))
     }
 }

--- a/validator-rust/src/components/transforms.rs
+++ b/validator-rust/src/components/transforms.rs
@@ -380,6 +380,7 @@ impl Component for proto::Equal {
 
         let (num_columns, num_records) = propagate_binary_shape(&left_property, &right_property)?;
 
+        println!("num_records: {:?}", num_records);
         Ok(ValueProperties::Array(ArrayProperties {
             nullity: false,
             releasable: left_property.releasable && right_property.releasable,
@@ -1299,9 +1300,9 @@ pub fn propagate_binary_shape(
     }
 
     // either left, right or both are broadcastable, so take the largest
-    let output_num_records = vec![l, r].iter().filter_map(|v| *v).max().unwrap();
+    let output_num_records = l.zip(r).map(|(l, r)| l.max(r));
 
-    Ok((output_num_columns, Some(output_num_records)))
+    Ok((output_num_columns, output_num_records))
 }
 
 pub fn propagate_unary_nature(

--- a/validator-rust/src/components/transforms.rs
+++ b/validator-rust/src/components/transforms.rs
@@ -380,7 +380,6 @@ impl Component for proto::Equal {
 
         let (num_columns, num_records) = propagate_binary_shape(&left_property, &right_property)?;
 
-        println!("num_records: {:?}", num_records);
         Ok(ValueProperties::Array(ArrayProperties {
             nullity: false,
             releasable: left_property.releasable && right_property.releasable,

--- a/validator-rust/src/components/union.rs
+++ b/validator-rust/src/components/union.rs
@@ -70,9 +70,14 @@ impl Component for proto::Union {
                 node_id: node_id as i64,
                 is_not_empty: array_props.iter().any(|v| v.is_not_empty),
                 dimensionality: Some(2),
-                group_id: get_group_id_path(array_props.iter()
-                    .map(|prop| prop.group_id.clone())
-                    .collect())?,
+                group_id: if releasable {
+                    // unnecessary to track group ids on public data
+                    vec![]
+                } else {
+                    get_group_id_path(array_props.iter()
+                        .map(|prop| prop.group_id.clone())
+                        .collect())?
+                },
                 naturally_ordered: false,
                 sample_proportion: None,
             })

--- a/validator-rust/src/utilities/mod.rs
+++ b/validator-rust/src/utilities/mod.rs
@@ -531,18 +531,18 @@ pub fn expand_mechanism(
         .ok_or_else(|| Error::from("aggregator: missing"))?;
 
     // sensitivity scaling
-    let mut sensitivity_value = aggregator.component.compute_sensitivity(
+    let sensitivity_value = aggregator.component.compute_sensitivity(
         privacy_definition,
         &aggregator.properties,
         &sensitivity_type)?;
 
     // TODO: debug axes in lipschitz constant arrays
-    let lipschitz = aggregator.lipschitz_constants.clone().array()?.float()?;
-    if lipschitz.iter().any(|v| v != &1.) {
-        let mut sensitivity = sensitivity_value.array()?.float()?;
-        sensitivity *= &lipschitz;
-        sensitivity_value = sensitivity.into();
-    }
+    // let lipschitz = aggregator.lipschitz_constants.clone().array()?.float()?;
+    // if lipschitz.iter().any(|v| v != &1.) {
+    //     let mut sensitivity = sensitivity_value.array()?.float()?;
+    //     sensitivity *= &lipschitz;
+    //     sensitivity_value = sensitivity.into();
+    // }
 
     maximum_id += 1;
     let id_sensitivity = maximum_id;


### PR DESCRIPTION
This PR fixes two privacy issues-
1. A sign in the analytic gaussian was not being set correctly, resulting in reduced sigma
2. The noise scale in the gaussian mechanism should not be squared

This PR fixes a number of issues with accuracy-
1. Accuracies for disjoint queries were incorrectly multiplied by the category length.
2. Accuracies for the gaussian mechanism were incorrectly using values for the analytic gaussian
3. Accuracies would not coerce integers to floats when necessary.

This PR also adds shapeness checks into the mechanism runtimes. Typically we don't write checks in the runtime- the validator handles this logic, and the runtime simply executes the computation. Checks that fail at runtime also have a tendency to leak information about the data. However, in this case, these checks provide a second layer of protection against mis-shapen data that was manually inserted into the graph. This comes up often when inserting pre-aggregated data from other systems. It is better to fail than to only noise the intersection of the actual and expected shapes.

This PR also computes integral sensitivities when possible, and improves support for integer-valued queries.