### PR TITLE
clamp simple geometric mechanism based on sampling bounds

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ### v0.1.1
 * Fix noise scaling issues in the Gaussian and Analytic Gaussian mechanism
 * Fixes for Gaussian and Analytic Gaussian accuracy
+* Postprocess geometric mechanism noise with clamping
 * Compute sensitivities as integers whenever possible (counts, histograms, sums)
 * Added runtime sanity checks to detect violations of static properties in pre-aggregated data
 * O(n^2) -> O(n) runtime performance in exponential mechanism and categorical imputation

--- a/ffi-rust/src/direct_api.rs
+++ b/ffi-rust/src/direct_api.rs
@@ -4,8 +4,8 @@ use smartnoise_runtime::utilities::mechanisms;
 pub extern "C" fn laplace_mechanism(
     value: f64, epsilon: f64, sensitivity: f64, enforce_constant_time: bool
 ) -> f64 {
-    value + mechanisms::laplace_mechanism(
-        epsilon, sensitivity, enforce_constant_time).unwrap()
+    mechanisms::laplace_mechanism(
+        value, epsilon, sensitivity, enforce_constant_time).unwrap()
 }
 
 #[no_mangle]
@@ -14,8 +14,8 @@ pub extern "C" fn gaussian_mechanism(
     analytic: bool,
     enforce_constant_time: bool,
 ) -> f64 {
-    value + mechanisms::gaussian_mechanism(
-        epsilon, delta, sensitivity, analytic, enforce_constant_time).unwrap()
+    mechanisms::gaussian_mechanism(
+        value, epsilon, delta, sensitivity, analytic, enforce_constant_time).unwrap()
 }
 
 #[no_mangle]
@@ -25,8 +25,8 @@ pub extern "C" fn simple_geometric_mechanism(
     min: i64, max: i64,
     enforce_constant_time: bool
 ) -> i64 {
-    value + mechanisms::simple_geometric_mechanism(
-        epsilon, sensitivity, min, max, enforce_constant_time).unwrap()
+    mechanisms::simple_geometric_mechanism(
+        value, epsilon, sensitivity, min, max, enforce_constant_time).unwrap()
 }
 
 

--- a/runtime-rust/src/components/mechanisms.rs
+++ b/runtime-rust/src/components/mechanisms.rs
@@ -49,9 +49,9 @@ impl Evaluable for proto::LaplaceMechanism {
                 .try_for_each(|(v, sens)|
 
                     utilities::mechanisms::laplace_mechanism(
-                        epsilon, *sens as f64,
+                        *v as Float, epsilon, *sens as f64,
                         enforce_constant_time,
-                    ).map(|noise| *v += noise as Float)))?;
+                    ).map(|noise| *v = noise as Float)))?;
 
         Ok(ReleaseNode {
             value: data.into(),
@@ -101,9 +101,9 @@ impl Evaluable for proto::GaussianMechanism {
                 .try_for_each(|(v, sens)|
 
                     utilities::mechanisms::gaussian_mechanism(
-                        epsilon, delta, *sens as f64, self.analytic,
+                        *v as Float, epsilon, delta, *sens as f64, self.analytic,
                         enforce_constant_time,
-                    ).map(|noise| *v += noise as Float)))?;
+                    ).map(|noise| *v = noise as Float)))?;
 
         Ok(ReleaseNode {
             value: data.into(),
@@ -154,10 +154,10 @@ impl Evaluable for proto::SimpleGeometricMechanism {
                 .try_for_each(|((v, sens), (c_min, c_max))|
 
                     utilities::mechanisms::simple_geometric_mechanism(
-                        epsilon, *sens as f64,
+                        *v as Integer, epsilon, *sens as f64,
                         *c_min as i64, *c_max as i64,
                         enforce_constant_time,
-                    ).map(|noise| *v += noise as Integer)))?;
+                    ).map(|noise| *v = noise as Integer)))?;
 
         Ok(ReleaseNode {
             value: data.into(),


### PR DESCRIPTION
Prevents a circumvention of privacy protections by setting `min == max`. The bounds for the statistic are not just important for calculating the maximum potential number of sampling iterations to run. In the case that `min == max`, then zero sampling rounds will be conducted, resulting in variance zero noise. This is clearly only DP if the distribution of the statistic is constant. More generally, this clamp is necessary anytime the range of derived bounds is greater than the range of manually provided bounds.