### PR TITLE
remove `automatic` histogram mechanism option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ If you plan to contribute new features, utility functions or extensions to the c
 
 ## Contributing Team
 
-Joshua Allen, Christian Covington, Eduardo de Leon, Ira Globus-Harris, James Honaker, Jason Huang, Saniya Movahed, Michael Phelan, Raman Prasad, Michael Shoemate, You?
+Joshua Allen, Ethan Cowan, Christian Covington, Eduardo de Leon, Ira Globus-Harris, James Honaker, Jason Huang, Saniya Movahed, Michael Phelan, Raman Prasad, Michael Shoemate, You?

--- a/validator-rust/src/components/dp_histogram.rs
+++ b/validator-rust/src/components/dp_histogram.rs
@@ -33,13 +33,6 @@ impl Expandable for proto::DpHistogram {
         let privacy_definition = privacy_definition.as_ref()
             .ok_or_else(|| Error::from("privacy_definition must be known"))?;
 
-        let mechanism = if self.mechanism.to_lowercase().as_str() == "automatic" {
-            if data_property.data_type == DataType::Int { "simplegeometric" } else {
-                if privacy_definition.protect_floating_point
-                { "snapping" } else { "laplace" }
-            }.to_string()
-        } else { self.mechanism.to_lowercase() };
-
         // histogram
         maximum_id += 1;
         let id_histogram = maximum_id;
@@ -59,7 +52,7 @@ impl Expandable for proto::DpHistogram {
         });
         expansion.traversal.push(id_histogram);
 
-        if mechanism.as_str() == "simplegeometric" {
+        if self.mechanism.to_lowercase() == "simplegeometric" {
             let count_min_id = match argument_ids.get::<IndexKey>(&"lower".into()) {
                 Some(id) => *id,
                 None => {
@@ -112,7 +105,7 @@ impl Expandable for proto::DpHistogram {
 
             // noising
             let mut arguments = indexmap!["data".into() => id_histogram];
-            let variant = Some(match mechanism.as_str() {
+            let variant = Some(match self.mechanism.to_lowercase() {
                 "laplace" => proto::component::Variant::LaplaceMechanism(proto::LaplaceMechanism {
                     privacy_usage: self.privacy_usage.clone()
                 }),

--- a/validator-rust/src/components/dp_histogram.rs
+++ b/validator-rust/src/components/dp_histogram.rs
@@ -2,7 +2,7 @@ use indexmap::map::IndexMap;
 use ndarray::arr0;
 
 use crate::{base, Integer, proto};
-use crate::base::{DataType, IndexKey, NodeProperties, Value};
+use crate::base::{IndexKey, NodeProperties, Value};
 use crate::components::{Expandable, Report};
 use crate::errors::*;
 use crate::utilities::{array::get_ith_column, get_literal, prepend, privacy::spread_privacy_usage};
@@ -105,7 +105,7 @@ impl Expandable for proto::DpHistogram {
 
             // noising
             let mut arguments = indexmap!["data".into() => id_histogram];
-            let variant = Some(match self.mechanism.to_lowercase() {
+            let variant = Some(match self.mechanism.to_lowercase().as_str() {
                 "laplace" => proto::component::Variant::LaplaceMechanism(proto::LaplaceMechanism {
                     privacy_usage: self.privacy_usage.clone()
                 }),


### PR DESCRIPTION
DPHistogram defaults to `SimpleGeometric`. If the user were to explicitly change the mechanism of DPHistogram to `automatic`, the system will un-necessarily choose the snapping or laplace mechanism if the data is not integral. Choosing the laplace or snapping mechanism is un-necessary because any float or categorical input data would be preprocessed by digitize and histogram to be integers. Since all situations are handled by the SimpleGeometric mechanism, the `automatic` option has been completely removed.