### PR TITLE
privacy_definition.protect_sensitivity and user-supplied sensitivity

### DIFF
--- a/ffi-rust/Cargo.toml
+++ b/ffi-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartnoise_ffi"
-version = "0.1.2"
+version = "0.2.1"
 authors = ["OpenDP-SmartNoise <smartnoise@opendp.io>"]
 description = "A wrapper library for interfacing with the SmartNoise over ffi."
 readme = "README.md"
@@ -17,11 +17,11 @@ indexmap = "1.4.0"
 
 [dependencies.smartnoise_validator]
 path = "../validator-rust/"
-version = "0.1.2"
+version = "0.2.1"
 
 [dependencies.smartnoise_runtime]
 path = "../runtime-rust/"
-version = "0.1.2"
+version = "0.2.1"
 optional = true
 default-features = false
 

--- a/runtime-rust/Cargo.toml
+++ b/runtime-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartnoise_runtime"
-version = "0.1.2"
+version = "0.2.1"
 authors = ["OpenDP-SmartNoise <smartnoise@opendp.io>"]
 description = "A library of algorithms for differentially private data analysis."
 readme = "README.md"
@@ -40,7 +40,7 @@ statrs = "0.12.0"
     optional = true
 
     [dependencies.smartnoise_validator]
-    version = "0.1.2"
+            version = "0.2.1"
     path = "../validator-rust/"
 
 [features]

--- a/scripts/update_version.toml
+++ b/scripts/update_version.toml
@@ -1,8 +1,8 @@
 [version]
 # version to update to
 major = 0
-minor = 1
-patch = 2
+minor = 2
+patch = 1
 
 
 [paths]

--- a/validator-rust/Cargo.toml
+++ b/validator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartnoise_validator"
-version = "0.1.2"
+version = "0.2.1"
 authors = ["OpenDP-SmartNoise <smartnoise@opendp.io>"]
 description = "A library for validating whether or not an analysis is differentially private."
 readme = "README.md"

--- a/validator-rust/prototypes/base.proto
+++ b/validator-rust/prototypes/base.proto
@@ -39,6 +39,8 @@ message PrivacyDefinition {
     bool protect_memory_utilization = 6;
     // enable to block mechanisms known to be vulnerable to floating point attacks
     bool protect_floating_point = 7;
+    // enable to prevent manual insertion of sensitivity to mechanisms
+    bool protect_sensitivity = 8;
 }
 
 message ComputationGraph {

--- a/validator-rust/prototypes/components/ExponentialMechanism.json
+++ b/validator-rust/prototypes/components/ExponentialMechanism.json
@@ -1,13 +1,19 @@
 {
   "arguments": {
-    "utilities": {
-      "type_value": "Array",
-      "description": "Respective scores for each candidate. Total number of records must match candidates."
-    },
-    "candidates": {
-      "type_value": "Array",
-      "description": "Set from which the Exponential mechanism will return an element. Total number of records must match utilities."
-    }
+      "utilities": {
+          "type_value": "Array",
+          "description": "Respective scores for each candidate. Total number of records must match candidates."
+      },
+      "candidates": {
+          "type_value": "Array",
+          "description": "Set from which the Exponential mechanism will return an element. Total number of records must match utilities."
+      },
+      "sensitivity": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Override the sensitivity computed by the library. Rejected unless `protect_sensitivity` is disabled."
+      }
   },
   "id": "ExponentialMechanism",
   "name": "exponential_mechanism",

--- a/validator-rust/prototypes/components/GaussianMechanism.json
+++ b/validator-rust/prototypes/components/GaussianMechanism.json
@@ -1,9 +1,15 @@
 {
   "arguments": {
-    "data": {
-      "type_value": "Array",
-      "description": "Result to be released privately via the Gaussian mechanism. Atomic type must be numeric."
-    }
+      "data": {
+          "type_value": "Array",
+          "description": "Result to be released privately via the Gaussian mechanism. Atomic type must be numeric."
+      },
+      "sensitivity": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Override the sensitivity computed by the library. Rejected unless `protect_sensitivity` is disabled."
+      }
   },
   "id": "GaussianMechanism",
   "name": "gaussian_mechanism",

--- a/validator-rust/prototypes/components/LaplaceMechanism.json
+++ b/validator-rust/prototypes/components/LaplaceMechanism.json
@@ -1,9 +1,15 @@
 {
   "arguments": {
-    "data": {
-      "type_value": "Array",
-      "description": "True value to be released privately via the Laplace mechanism."
-    }
+      "data": {
+          "type_value": "Array",
+          "description": "True value to be released privately via the Laplace mechanism."
+      },
+      "sensitivity": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Override the sensitivity computed by the library. Rejected unless `protect_sensitivity` is disabled."
+      }
   },
   "id": "LaplaceMechanism",
   "name": "laplace_mechanism",

--- a/validator-rust/prototypes/components/SimpleGeometricMechanism.json
+++ b/validator-rust/prototypes/components/SimpleGeometricMechanism.json
@@ -1,19 +1,25 @@
 {
   "arguments": {
-    "data": {
-      "type_value": "Array",
-      "description": "Result to be released privately via the Geometric mechanism. Member data type must be integer."
-    },
-    "lower": {
-      "type_value": "Array",
-      "default_python": "None",
-      "description": "Lower bound of the statistic to be privatized. Member data type must be integer."
-    },
-    "upper": {
-      "type_value": "Array",
-      "default_python": "None",
-      "description": "Upper bound of the statistic to be privatized. Member data type must be integer."
-    }
+      "data": {
+          "type_value": "Array",
+          "description": "Result to be released privately via the Geometric mechanism. Member data type must be integer."
+      },
+      "lower": {
+          "type_value": "Array",
+          "default_python": "None",
+          "description": "Lower bound of the statistic to be privatized. Member data type must be integer."
+      },
+      "upper": {
+          "type_value": "Array",
+          "default_python": "None",
+          "description": "Upper bound of the statistic to be privatized. Member data type must be integer."
+      },
+      "sensitivity": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Override the sensitivity computed by the library. Rejected unless `protect_sensitivity` is disabled."
+      }
   },
   "id": "SimpleGeometricMechanism",
   "name": "simple_geometric_mechanism",

--- a/validator-rust/prototypes/components/SnappingMechanism.json
+++ b/validator-rust/prototypes/components/SnappingMechanism.json
@@ -1,27 +1,33 @@
 {
   "arguments": {
-    "data": {
-      "type_value": "Array",
-      "description": "Result to be released privately via the Snapping mechanism. Array members must be of type float or of type integer."
-    },
-    "lower": {
-      "type_value": "Array",
-      "default_python": "None",
-      "default_rust": "None",
-      "description": "Estimated minimum possible value of the data. Only useful for the snapping mechanism. This argument is required."
-    },
-    "upper": {
-      "type_value": "Array",
-      "default_python": "None",
-      "default_rust": "None",
-      "description": "Estimated maximum possible value of the statistic. Only useful for the snapping mechanism. This argument is required."
-    },
-    "binding_probability": {
-      "type_value": "Array",
-      "default_python": "None",
-      "default_rust": "None",
-      "description": "Upper bound on probability that final clamp binds. Must be within [0, 1)."
-    }
+      "data": {
+          "type_value": "Array",
+          "description": "Result to be released privately via the Snapping mechanism. Array members must be of type float or of type integer."
+      },
+      "lower": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Estimated minimum possible value of the data. Only useful for the snapping mechanism. This argument is required."
+      },
+      "upper": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Estimated maximum possible value of the statistic. Only useful for the snapping mechanism. This argument is required."
+      },
+      "binding_probability": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Upper bound on probability that final clamp binds. Must be within [0, 1)."
+      },
+      "sensitivity": {
+          "type_value": "Array",
+          "default_python": "None",
+          "default_rust": "None",
+          "description": "Override the sensitivity computed by the library. Rejected unless `protect_sensitivity` is disabled."
+      }
   },
   "id": "SnappingMechanism",
   "name": "snapping_mechanism",

--- a/validator-rust/src/bindings.rs
+++ b/validator-rust/src/bindings.rs
@@ -49,7 +49,8 @@ impl Analysis {
                 protect_overflow: false,
                 protect_elapsed_time: false,
                 protect_memory_utilization: false,
-                protect_floating_point: false
+                protect_floating_point: true,
+                protect_sensitivity: true
             },
             components: HashMap::new(),
             component_count: 0,

--- a/validator-rust/src/components/exponential_mechanism.rs
+++ b/validator-rust/src/components/exponential_mechanism.rs
@@ -119,24 +119,8 @@ impl Expandable for proto::ExponentialMechanism {
             .ok_or("utilities: missing")?.array()
             .map_err(prepend("utilities:"))?.clone();
 
-        let aggregator = utilities_properties.aggregator
-            .ok_or_else(|| Error::from("aggregator: missing"))?;
-
-        let sensitivity = aggregator.component.compute_sensitivity(
-            privacy_definition,
-            &aggregator.properties,
-            &SensitivitySpace::Exponential)?;
-
-        maximum_id += 1;
-        let id_sensitivity = maximum_id;
-        let (patch_node, release) = get_literal(sensitivity, component.submission)?;
-        expansion.computation_graph.insert(id_sensitivity, patch_node);
-        expansion.properties.insert(id_sensitivity, infer_property(&release.value, None, id_sensitivity)?);
-        expansion.releases.insert(id_sensitivity, release);
-
         // noising
         let mut noise_component = component.clone();
-        noise_component.insert_argument(&"sensitivity".into(), id_sensitivity);
 
         if self.privacy_usage.len() != 1 {
             return Err(Error::from("privacy usage must be of length one"));
@@ -150,6 +134,26 @@ impl Expandable for proto::ExponentialMechanism {
                 privacy_definition.group_size)?];
             // this case should never happen
         } else { return Err(Error::from("Variant must be defined")) }
+
+        if privacy_definition.protect_sensitivity || !properties.contains_key(&IndexKey::from("sensitivity")) {
+            let aggregator = utilities_properties.aggregator
+                .ok_or_else(|| Error::from("aggregator: missing"))?;
+
+            let sensitivity = aggregator.component.compute_sensitivity(
+                privacy_definition,
+                &aggregator.properties,
+                &SensitivitySpace::Exponential)?;
+
+            // exponential sensitivity cannot currently be modified by lipschitz constants
+
+            maximum_id += 1;
+            let id_sensitivity = maximum_id;
+            let (patch_node, release) = get_literal(sensitivity, component.submission)?;
+            expansion.computation_graph.insert(id_sensitivity, patch_node);
+            expansion.properties.insert(id_sensitivity, infer_property(&release.value, None, id_sensitivity)?);
+            expansion.releases.insert(id_sensitivity, release);
+            noise_component.insert_argument(&"sensitivity".into(), id_sensitivity);
+        }
 
         expansion.computation_graph.insert(component_id, noise_component);
 

--- a/validator-rust/src/components/gaussian_mechanism.rs
+++ b/validator-rust/src/components/gaussian_mechanism.rs
@@ -125,31 +125,18 @@ impl Mechanism for proto::GaussianMechanism {
 impl Accuracy for proto::GaussianMechanism {
     fn accuracy_to_privacy_usage(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &base::NodeProperties,
         accuracies: &proto::Accuracies,
-        _public_arguments: IndexMap<base::IndexKey, &Value>
+        mut public_arguments: IndexMap<base::IndexKey, &Value>
     ) -> Result<Option<Vec<proto::PrivacyUsage>>> {
-        let data_property = properties.get::<IndexKey>(&"data".into())
-            .ok_or("data: missing")?.array()
-            .map_err(prepend("data:"))?.clone();
-
-        let aggregator = data_property.aggregator.as_ref()
-            .ok_or_else(|| Error::from("aggregator: missing"))?;
-
-        // sensitivity must be computable
-        let sensitivity_values = aggregator.component.compute_sensitivity(
-            &privacy_definition,
-            &aggregator.properties,
-            &SensitivitySpace::KNorm(2))?;
-
         // take max sensitivity of each column
-        let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?
+        let sensitivities: Vec<_> = public_arguments.remove(&IndexKey::from("sensitivity"))
+            .ok_or_else(|| Error::from("sensitivity: missing in accuracy"))?.clone()
+            .array()?.cast_float()?
             .gencolumns().into_iter()
             .map(|sensitivity_col| sensitivity_col.into_iter().copied().fold1(|l, r| l.max(r)).unwrap())
             .collect();
 
-        let usages = spread_privacy_usage(&self.privacy_usage, data_property.num_columns()? as usize)?;
+        let usages = spread_privacy_usage(&self.privacy_usage, sensitivities.len())?;
         let delta = usages.iter().map(get_delta).collect::<Result<Vec<f64>>>()?;
         let iter = izip!(sensitivities.into_iter(), accuracies.values.iter(), delta.into_iter());
 
@@ -173,26 +160,13 @@ impl Accuracy for proto::GaussianMechanism {
 
     fn privacy_usage_to_accuracy(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &base::NodeProperties,
-        _public_arguments: IndexMap<base::IndexKey, &Value>,
+        mut public_arguments: IndexMap<base::IndexKey, &Value>,
         alpha: f64,
     ) -> Result<Option<Vec<proto::Accuracy>>> {
-        let data_property = properties.get::<IndexKey>(&"data".into())
-            .ok_or("data: missing")?.array()
-            .map_err(prepend("data:"))?.clone();
-
-        let aggregator = data_property.aggregator
-            .ok_or_else(|| Error::from("aggregator: missing"))?;
-
-        // sensitivity must be computable
-        let sensitivity_values = aggregator.component.compute_sensitivity(
-            &privacy_definition,
-            &aggregator.properties,
-            &SensitivitySpace::KNorm(2))?;
-
         // take max sensitivity of each column
-        let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?
+        let sensitivities: Vec<_> = public_arguments.remove(&IndexKey::from("sensitivity"))
+            .ok_or_else(|| Error::from("sensitivity: missing in accuracy"))?.clone()
+            .array()?.cast_float()?
             .gencolumns().into_iter()
             .map(|sensitivity_col| sensitivity_col.into_iter().copied().fold1(|l, r| l.max(r)).unwrap())
             .collect();

--- a/validator-rust/src/components/mod.rs
+++ b/validator-rust/src/components/mod.rs
@@ -182,16 +182,12 @@ pub trait Sensitivity {
 pub trait Accuracy {
     fn accuracy_to_privacy_usage(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &NodeProperties,
         accuracies: &proto::Accuracies,
         public_arguments: IndexMap<base::IndexKey, &Value>
     ) -> Result<Option<Vec<proto::PrivacyUsage>>>;
 
     fn privacy_usage_to_accuracy(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &NodeProperties,
         public_arguments: IndexMap<base::IndexKey, &Value>,
         alpha: f64,
     ) -> Result<Option<Vec<proto::Accuracy>>>;
@@ -426,8 +422,6 @@ impl Accuracy for proto::Component {
     /// This utility delegates evaluation to the concrete implementation of each component variant.
     fn accuracy_to_privacy_usage(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &NodeProperties,
         accuracy: &proto::Accuracies,
         public_arguments: IndexMap<base::IndexKey, &Value>
     ) -> Result<Option<Vec<proto::PrivacyUsage>>> {
@@ -439,8 +433,7 @@ impl Accuracy for proto::Component {
                 {
                     $(
                        if let proto::component::Variant::$variant(x) = variant {
-                            return x.accuracy_to_privacy_usage(
-                                privacy_definition, properties, accuracy, public_arguments)
+                            return x.accuracy_to_privacy_usage(accuracy, public_arguments)
                                 .chain_err(|| format!("node specification {:?}:", variant))
                        }
                     )*
@@ -463,8 +456,6 @@ impl Accuracy for proto::Component {
     /// This utility delegates evaluation to the concrete implementation of each component variant.
     fn privacy_usage_to_accuracy(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &NodeProperties,
         public_arguments: IndexMap<base::IndexKey, &Value>,
         alpha: f64,
     ) -> Result<Option<Vec<proto::Accuracy>>> {
@@ -476,8 +467,7 @@ impl Accuracy for proto::Component {
                 {
                     $(
                        if let proto::component::Variant::$variant(x) = variant {
-                            return x.privacy_usage_to_accuracy(
-                                privacy_definition, properties, public_arguments, alpha)
+                            return x.privacy_usage_to_accuracy(public_arguments, alpha)
                                 .chain_err(|| format!("node specification {:?}:", variant))
                        }
                     )*

--- a/validator-rust/src/components/simple_geometric_mechanism.rs
+++ b/validator-rust/src/components/simple_geometric_mechanism.rs
@@ -149,26 +149,13 @@ impl Mechanism for proto::SimpleGeometricMechanism {
 impl Accuracy for proto::SimpleGeometricMechanism {
     fn accuracy_to_privacy_usage(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &base::NodeProperties,
         accuracies: &proto::Accuracies,
-        _public_arguments: IndexMap<base::IndexKey, &Value>
+        mut public_arguments: IndexMap<base::IndexKey, &Value>
     ) -> Result<Option<Vec<proto::PrivacyUsage>>> {
-        let data_property = properties.get::<IndexKey>(&"data".into())
-            .ok_or("data: missing")?.array()
-            .map_err(prepend("data:"))?.clone();
-
-        let aggregator = data_property.aggregator
-            .ok_or_else(|| Error::from("aggregator: missing"))?;
-
-        // sensitivity must be computable
-        let sensitivity_values = aggregator.component.compute_sensitivity(
-            &privacy_definition,
-            &aggregator.properties,
-            &SensitivitySpace::KNorm(1))?;
-
         // take max sensitivity of each column
-        let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?
+        let sensitivities: Vec<_> = public_arguments.remove(&IndexKey::from("sensitivity"))
+            .ok_or_else(|| Error::from("sensitivity: missing in accuracy"))?.clone()
+            .array()?.cast_float()?
             .gencolumns().into_iter()
             .map(|sensitivity_col| sensitivity_col.into_iter().copied().fold1(|l, r| l.max(r)).unwrap())
             .collect();
@@ -185,30 +172,18 @@ impl Accuracy for proto::SimpleGeometricMechanism {
 
     fn privacy_usage_to_accuracy(
         &self,
-        privacy_definition: &proto::PrivacyDefinition,
-        properties: &base::NodeProperties,
-        _public_arguments: IndexMap<base::IndexKey, &Value>,
+        mut public_arguments: IndexMap<base::IndexKey, &Value>,
         alpha: f64,
     ) -> Result<Option<Vec<proto::Accuracy>>> {
-        let data_property = properties.get::<IndexKey>(&"data".into())
-            .ok_or("data: missing")?.array()
-            .map_err(prepend("data:"))?.clone();
-
-        let aggregator = data_property.aggregator.as_ref()
-            .ok_or_else(|| Error::from("aggregator: missing"))?;
-
-        let sensitivity_values = aggregator.component.compute_sensitivity(
-            &privacy_definition,
-            &aggregator.properties,
-            &SensitivitySpace::KNorm(1))?;
-
         // take max sensitivity of each column
-        let sensitivities: Vec<_> = sensitivity_values.array()?.cast_float()?
+        let sensitivities: Vec<_> = public_arguments.remove(&IndexKey::from("sensitivity"))
+            .ok_or_else(|| Error::from("sensitivity: missing in accuracy"))?.clone()
+            .array()?.cast_float()?
             .gencolumns().into_iter()
             .map(|sensitivity_col| sensitivity_col.into_iter().copied().fold1(|l, r| l.max(r)).unwrap())
             .collect();
 
-        let usages = spread_privacy_usage(&self.privacy_usage, data_property.num_columns()? as usize)?;
+        let usages = spread_privacy_usage(&self.privacy_usage, sensitivities.len())?;
         let epsilon = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
 
         Ok(Some(sensitivities.into_iter().zip(epsilon.into_iter())

--- a/validator-rust/src/lib.rs
+++ b/validator-rust/src/lib.rs
@@ -227,22 +227,16 @@ pub fn accuracy_to_privacy_usage(
         component.arguments().values().max().cloned().unwrap_or(0) + 1 => component
     ];
 
-    let (properties, _) = utilities::propagate_properties(
+    utilities::propagate_properties(
         &Some(privacy_definition.clone()),
-            &mut computation_graph,
+        &mut computation_graph,
         &mut release,
         Some(proto_properties),
         true,
     )?;
 
     let privacy_usages = computation_graph.iter().map(|(idx, component)| {
-        let component_properties = component.arguments().iter()
-            .filter_map(|(name, idx)| Some((name.clone(), properties.get(idx)?.clone())))
-            .collect::<IndexMap<base::IndexKey, base::ValueProperties>>();
-
         Ok(component.accuracy_to_privacy_usage(
-            &privacy_definition,
-            &component_properties,
             &accuracies,
             get_public_arguments(&component, &release)?)?
             .and_then(|usages| Some((*idx, usages))))
@@ -282,7 +276,7 @@ pub fn privacy_usage_to_accuracy(
         component.arguments().values().max().cloned().unwrap_or(0) + 1 => component
     ];
 
-    let (properties, _) = utilities::propagate_properties(
+    utilities::propagate_properties(
         &Some(privacy_definition.clone()),
         &mut computation_graph,
         &mut release,
@@ -291,13 +285,7 @@ pub fn privacy_usage_to_accuracy(
     )?;
 
     let accuracies = computation_graph.iter().map(|(idx, component)| {
-        let component_properties = component.arguments().iter()
-            .filter_map(|(name, idx)| Some((name.clone(), properties.get(idx)?.clone())))
-            .collect::<IndexMap<IndexKey, base::ValueProperties>>();
-
         Ok(component.privacy_usage_to_accuracy(
-            &privacy_definition,
-            &component_properties,
             get_public_arguments(&component, &release)?,
             alpha,
         )?


### PR DESCRIPTION
Allow researchers to override sensitivity in reduced-security privacy definitions. 
In reference to https://github.com/opendifferentialprivacy/smartnoise-core/issues/329.