### PR TITLE
sensitivity argument checks

### DIFF
--- a/validator-rust/prototypes/components/Partition.json
+++ b/validator-rust/prototypes/components/Partition.json
@@ -21,6 +21,6 @@
   "return": {
     "type_value": "Indexmap"
   },
-  "description": "Split the rows of data into either into k equally sized partitions, or by the categories of a vector",
+  "description": "Split the rows of data into either k equally sized partitions, or by the categories of a vector",
   "proto_id": 45
 }


### PR DESCRIPTION
Passing sensitivity when protections are enabled fails the computation. Passing mis-shapen sensitivities fails the computation.